### PR TITLE
Update README.md for errata

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Qualitative results
 To download and extract celeb for example, run
 ```
 wget https://storage.googleapis.com/glow-demo/data/celeba-tfr.tar
-tar -xvf celeb-tfr.tar
+tar -xvf celeba-tfr.tar
 ```
 Change `hps.data_dir` in train.py file to point to the above folder (or use the `--data_dir` flag when you run train.py)
 


### PR DESCRIPTION
While testing GLOW, I found a very small errata, as shown below. Modify this.

wget https://storage.googleapis.com/glow-demo/data/celeba-tfr.tar
tar -xvf **celeb-tfr.tar**

=>

wget https://storage.googleapis.com/glow-demo/data/celeba-tfr.tar
tar -xvf **celeba-tfr.tar**

Missing the "a" character.